### PR TITLE
Add input testing to configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ var _ = require('lodash');
 var strObj = require('string');
 var join = require('path').join;
 var deref = require('json-schema-deref-sync');
+var helpers = require('./lib/helpers.js');
 var len;
 
 /**
@@ -86,6 +87,18 @@ function getData(swagger, path, operation, response, config, info) {
   // get pathParams from config
   if (config.pathParams) {
     data.pathParams = config.pathParams;
+  }
+
+  //used for checking inputTesting table
+  var tempPath = (((swagger.basePath !== undefined) && (swagger.basePath !== '/'))
+      ? swagger.basePath : '') + path;
+
+  // get inputTesting from config if defined for this path:operation:response
+  if (config.inputTesting &&
+      config.inputTesting[tempPath] &&
+      config.inputTesting[tempPath][operation] &&
+      config.inputTesting[tempPath][operation][response]) {
+    data.inputTesting = config.inputTesting[tempPath][operation][response];
   }
 
   // cope with loadTest info
@@ -239,7 +252,17 @@ function testGenResponse(swagger, path, operation, response, config,
 
   source = read(templatePath, 'utf8');
   templateFn = handlebars.compile(source, {noEscape: true});
-  result = templateFn(data);
+
+  if (data.inputTesting && data.inputTesting.length > 0) {
+    result = "";
+    for (var i = 0; i < data.inputTesting.length; i++) {
+      data.inputs = data.inputTesting[i];
+      result += templateFn(data);
+    }
+  } else {
+    result = templateFn(data);
+  }
+
   return result;
 }
 
@@ -505,127 +528,13 @@ function testGen(swagger, config) {
   return output;
 }
 
+handlebars.registerHelper('is', helpers.is);
+handlebars.registerHelper('ifCond', helpers.ifCond);
+handlebars.registerHelper('validateResponse', helpers.validateResponse);
+handlebars.registerHelper('length', helpers.length);
+handlebars.registerHelper('pathify', helpers.pathify);
+handlebars.registerHelper('printJSON', helpers.printJSON);
+
 module.exports = {
   testGen: testGen
 };
-
-// http://goo.gl/LFoiYG
-handlebars.registerHelper('is', function(lvalue, rvalue, options) {
-  if (arguments.length < 3) {
-    throw new Error('Handlebars Helper \'is\' needs 2 parameters');
-  }
-
-  if (lvalue !== rvalue) {
-    return options.inverse(this);
-  } else {
-    return options.fn(this);
-  }
-});
-
-// http://goo.gl/LFoiYG
-handlebars.registerHelper('ifCond', function(v1, v2, options) {
-  if (arguments.length < 3) {
-    throw new Error('Handlebars Helper \'ifCond\' needs 2 parameters');
-  }
-  if (v1.length > 0 || v2) {
-    return options.fn(this);
-  }
-  return options.inverse(this);
-});
-
-/**
- * determines if content types are able to be validated
- * @param  {string} type     content type to be evaluated
- * @param  {boolean} noSchema whether or not there is a defined schema
- * @param  {Object} options  handlebars built-in options
- * @returns {boolean}          whether or not the content can be validated
- */
-handlebars.registerHelper('validateResponse', function(type, noSchema,
-  options) {
-  if (arguments.length < 3) {
-    throw new Error('Handlebars Helper \'validateResponse\'' +
-      'needs 2 parameters');
-  }
-
-  if (!noSchema && type === TYPE_JSON) {
-    return options.fn(this);
-  } else {
-    return options.inverse(this);
-  }
-});
-
-/**
- * replaces path params with obvious indicator for filling values
- * (i.e. if any part of the path is surrounded in curly braces {})
- * @param  {string} path  request path to be pathified
- * @param  {object} pathParams contains path parameters to replace with
- * @returns {string}          pathified string
- */
-handlebars.registerHelper('pathify', function(path, pathParams) {
-  var r;
-
-  if (arguments.length < 3) {
-    throw new Error('Handlebars Helper \'pathify\'' +
-      ' needs 2 parameters');
-  }
-
-  if ((typeof path) !== 'string') {
-    throw new TypeError('Handlebars Helper \'pathify\'' +
-      'requires path to be a string');
-  }
-
-  if ((typeof pathParams) !== 'object') {
-    throw new TypeError('Handlebars Helper \'pathify\'' +
-      'requires pathParams to be an object');
-  }
-
-  if (Object.keys(pathParams).length > 0) {
-    var re = new RegExp(/(?:\{+)(.*?(?=\}))(?:\}+)/g);
-    var re2;
-    var matches = [];
-    var m = re.exec(path);
-    var i;
-
-    while (m) {
-      matches.push(m[1]);
-      m = re.exec(path);
-    }
-
-    for (i = 0; i < matches.length; i++) {
-      var match = matches[i];
-
-      re2 = new RegExp('(\\{+)' + match + '(?=\\})(\\}+)');
-
-      if (typeof (pathParams[match]) !== 'undefined' &&
-          pathParams[match] !== null) {
-        // console.log("Match found for "+match+": "+pathParams[match]);
-        path = path.replace(re2, pathParams[match]);
-      } else {
-        // console.log("No match found for "+match+": "+pathParams[match]);
-        path = path.replace(re2, '{' + match + ' PARAM GOES HERE}');
-      }
-    }
-    return path;
-  }
-
-  r = new RegExp(/(?:\{+)(.*?(?=\}))(?:\}+)/g);
-  return path.replace(r, '{$1 PARAM GOES HERE}');
-});
-
-/**
- * split the long description into multiple lines
- * @param  {string} description  request description to be splitted
- * @returns {string}        multiple lines
- */
-handlebars.registerHelper('length', function(description) {
-  if (arguments.length < 2) {
-    throw new Error('Handlebar Helper \'length\'' +
-    ' needs 1 parameter');
-  }
-
-  if ((typeof description) !== 'string') {
-    throw new TypeError('Handlebars Helper \'length\'' +
-      'requires path to be a string');
-  }
-  return strObj(description).truncate(len - 50).s;
-});

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,184 @@
+'use strict';
+
+var _ = require('lodash');
+var strObj = require('string');
+var url = require('url');
+var TYPE_JSON = 'application/json';
+var len;
+
+module.exports = {
+  is: is,
+  ifCond: ifCond,
+  validateResponse: validateResponse,
+  length: length,
+  pathify: pathify,
+  printJSON: printJSON
+}
+
+// http://goo.gl/LFoiYG
+function is(lvalue, rvalue, options) {
+  if (arguments.length < 3) {
+    throw new Error('Handlebars Helper \'is\' needs 2 parameters');
+  }
+
+  if (lvalue !== rvalue) {
+    return options.inverse(this);
+  } else {
+    return options.fn(this);
+  }
+}
+
+// http://goo.gl/LFoiYG
+function ifCond(v1, v2, options) {
+  if (arguments.length < 3) {
+    throw new Error('Handlebars Helper \'ifCond\' needs 2 parameters');
+  }
+  if (v1.length > 0 || v2) {
+    return options.fn(this);
+  }
+  return options.inverse(this);
+}
+
+/**
+ * determines if content types are able to be validated
+ * @param  {string} type     content type to be evaluated
+ * @param  {boolean} noSchema whether or not there is a defined schema
+ * @param  {Object} options  handlebars built-in options
+ * @returns {boolean}          whether or not the content can be validated
+ */
+function validateResponse(type, noSchema,
+  options) {
+  if (arguments.length < 3) {
+    throw new Error('Handlebars Helper \'validateResponse\'' +
+      'needs 2 parameters');
+  }
+
+  if (!noSchema && type === TYPE_JSON) {
+    return options.fn(this);
+  } else {
+    return options.inverse(this);
+  }
+}
+
+/**
+ * replaces path params with obvious indicator for filling values
+ * (i.e. if any part of the path is surrounded in curly braces {})
+ * @param  {string} path  request path to be pathified
+ * @param  {object} pathParams contains path parameters to replace with
+ * @returns {string}          pathified string
+ */
+function pathify(path, pathParams) {
+  var r;
+
+  if (arguments.length < 3) {
+    throw new Error('Handlebars Helper \'pathify\'' +
+      ' needs 2 parameters');
+  }
+
+  if ((typeof path) !== 'string') {
+    throw new TypeError('Handlebars Helper \'pathify\'' +
+      'requires path to be a string');
+  }
+
+  if ((typeof pathParams) !== 'object') {
+    throw new TypeError('Handlebars Helper \'pathify\'' +
+      'requires pathParams to be an object');
+  }
+
+  if (Object.keys(pathParams).length > 0) {
+    var re = new RegExp(/(?:\{+)(.*?(?=\}))(?:\}+)/g);
+    var re2;
+    var matches = [];
+    var m = re.exec(path);
+    var i;
+
+    while (m) {
+      matches.push(m[1]);
+      m = re.exec(path);
+    }
+
+    for (i = 0; i < matches.length; i++) {
+      var match = matches[i];
+
+      re2 = new RegExp('(\\{+)' + match + '(?=\\})(\\}+)');
+
+      if (typeof (pathParams[match]) !== 'undefined' &&
+          pathParams[match] !== null) {
+        // console.log("Match found for "+match+": "+pathParams[match]);
+        path = path.replace(re2, pathParams[match]);
+      } else {
+        // console.log("No match found for "+match+": "+pathParams[match]);
+        path = path.replace(re2, '{' + match + ' PARAM GOES HERE}');
+      }
+    }
+    return path;
+  }
+
+  r = new RegExp(/(?:\{+)(.*?(?=\}))(?:\}+)/g);
+  return path.replace(r, '{$1 PARAM GOES HERE}');
+});
+
+/**
+ * split the long description into multiple lines
+ * @param  {string} description  request description to be splitted
+ * @returns {string}        multiple lines
+ */
+function length(description) {
+  if (arguments.length < 2) {
+    throw new Error('Handlebar Helper \'length\'' +
+    ' needs 1 parameter');
+  }
+
+  if ((typeof description) !== 'string') {
+    throw new TypeError('Handlebars Helper \'length\'' +
+      'requires path to be a string');
+  }
+  return strObj(description).truncate(len - 50).s;
+}
+
+function printJSON(data) {
+  if (arguments.length < 2) {
+    throw new Error('Handlebar Helper \'printJSON\'' +
+    ' needs at least 1 parameter');
+  }
+
+  if (data !== null) {
+    if ((typeof data) === 'string') {
+      return '\'' + data + '\'';
+    } else if ((typeof data) === 'object') {
+      return '{\n'+prettyPrintJson(data, '        ')+'\n      }';
+    } else {
+      return data;
+    }
+  } else {
+    return null;
+  }
+}
+
+// http://goo.gl/7DbFS
+function prettyPrintJson(obj, indent) {
+  var result = '';
+
+  if (indent == null) indent = '';
+
+  for (var property in obj) {
+    if (property.charAt(0) !== '_') {
+      var value = obj[property];
+
+      if (typeof value === 'string') {
+        value = '\'' + value + '\'';
+      } else if (typeof value === 'object') {
+        if (value instanceof Array) {
+          value = '[ ' + value + ' ]';
+        } else {
+          // Recursive dump
+          var od = prettyPrintJson(value, indent + '  ');
+
+          value = '{\n' + od + '\n' + indent + '}';
+        }
+      }
+      result += indent + property + ': ' + value + ',\n';
+    }
+  }
+  return result.replace(/,\n$/, '');
+}

--- a/templates/supertest/patch/patch.handlebars
+++ b/templates/supertest/patch/patch.handlebars
@@ -1,4 +1,4 @@
-  it('should respond with {{length description}}', function(done) {
+  it("should respond with {{length description}}{{#if inputs}}, {{inputs.body.message}}{{/if}}", function(done) {
       {{#validateResponse returnType noSchema}}
       /*eslint-disable*/
       {{> schema-partial this}}
@@ -28,11 +28,15 @@
       .set('{{headerApiKey.type}}', process.env.{{headerApiKey.name}})
       {{/if}}
       {{#is contentType 'application/json'}}
+      {{#if inputs.body}}
+      .send({{printJSON inputs.body.data}})
+      {{else}}
       .send({
         {{#each bodyParameters}}
         {{this.name}}: 'DATA GOES HERE'{{#unless @last}},{{/unless}}
         {{/each}}
       })
+      {{/if}}
       {{/is}}
       {{#is contentType 'application/x-www-form-urlencoded'}}
       .send({

--- a/templates/supertest/post/post.handlebars
+++ b/templates/supertest/post/post.handlebars
@@ -1,4 +1,4 @@
-  it('should respond with {{length description}}', function(done) {
+  it("should respond with {{length description}}{{#if inputs}}, {{inputs.body.message}}{{/if}}", function(done) {
       {{#validateResponse returnType noSchema}}
       /*eslint-disable*/
       {{> schema-partial this}}
@@ -27,11 +27,15 @@
       .set('{{headerApiKey.type}}', process.env.{{headerApiKey.name}})
       {{/if}}
       {{#is contentType 'application/json'}}
+      {{#if inputs.body}}
+      .send({{printJSON inputs.body.data}})
+      {{else}}
       .send({
         {{#each bodyParameters}}
         {{this.name}}: 'DATA GOES HERE'{{#unless @last}},{{/unless}}
         {{/each}}
       })
+      {{/if}}
       {{/is}}
       {{#is contentType 'application/x-www-form-urlencoded'}}
       .send({

--- a/templates/supertest/put/put.handlebars
+++ b/templates/supertest/put/put.handlebars
@@ -1,4 +1,4 @@
-  it('should respond with {{length description}}', function(done) {
+  it("should respond with {{description}}{{#if inputs}}, {{inputs.body.message}}{{/if}}", function(done) {
       {{#validateResponse returnType noSchema}}
       /*eslint-disable*/
       {{> schema-partial this}}
@@ -27,11 +27,15 @@
       .set('{{headerApiKey.type}}', process.env.{{headerApiKey.name}})
       {{/if}}
       {{#is contentType 'application/json'}}
+      {{#if inputs.body}}
+      .send({{printJSON inputs.body.data}})
+      {{else}}
       .send({
         {{#each bodyParameters}}
         {{this.name}}: 'DATA GOES HERE'{{#unless @last}},{{/unless}}
         {{/each}}
       })
+      {{/if}}
       {{/is}}
       {{#is contentType 'application/x-www-form-urlencoded'}}
       .send({


### PR DESCRIPTION
- Added feature that allows for `inputTesting` to be supplied to
  configuration that provides datasets as a JSON object in the form:

```
{
  "a/path": { //path
    "post": { //operation
      "200": [ //response
        { "body": JSON_DATA }
      ],
      "400": [
        { "body": JSON_DATA }
      ]
    }
  }
}
```
- Moved helpers to `/lib/helpers.js`
- Added `printJSON` helper
- Modified `testGenResponse` to check to see if there is inputTesting
  defined for that particular `path:operation:response`, if so, set
  special variable `inputs` and use the templateFn for each dataset
- Modified templates for put, post, and patch (these are the ones where
  request bodies are allowed) to check for `inputs`, and if defined, it
  will run the template for each dataset. Otherwise, it runs the template
  once as usual
