### PR TITLE
add toggle for description truncation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,7 +33,7 @@
     wrap-iife: 2
     one-var: [2, "never"]
     quote-props: [2, "as-needed"]
-    max-len: [2, 80, 2]
+    max-len: [2, 160, 2]
     yoda: [2, "never"]
     dot-notation: 2
     new-cap: 2

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ stt.testGen(swagger, config);
 * **`testModule`** *required*: One of `supertest` or `request`. Choose between direct API calls (`request`) vs. programatic access to your API (`supertest`).
 * **`pathNames`** *required*: List of path names available in your Swagger API spec used to generate tests for. Empty array leads to **all paths**.
 * **`loadTest`** *optional*: List of objects info in your Swagger API spec used to generate stress tests. If specify, pathName & operation are **required**. Optional fields requests defaults to `1000`, concurrent defaults to `100`.
-* **`maxLen`** *optional*: Maximum line length. Defaults to `80`.
+* **`maxLen`** *optional*: Maximum line length. If set to `-1`, descriptions will not be truncated. Defaults to `80`.
 * **`pathParams`** *optional*: Object containing the values of a specific path parameters.
 
 #### Return value

--- a/index.js
+++ b/index.js
@@ -446,7 +446,6 @@ function testGen(swagger, config) {
   var schemaTemp;
   var environment;
   var ndx = 0;
-  var len;
 
   swagger = deref(swagger);
   source = read(join(__dirname, 'templates/schema.handlebars'), 'utf8');
@@ -454,10 +453,10 @@ function testGen(swagger, config) {
   handlebars.registerPartial('schema-partial', schemaTemp);
   source = read(join(__dirname, '/templates/environment.handlebars'), 'utf8');
   environment = handlebars.compile(source, {noEscape: true});
-  len = 80;
+  helpers.len = 80;
 
   if (config.maxLen && !isNaN(config.maxLen)) {
-    len = config.maxLen;
+    helpers.len = config.maxLen;
   }
 
   if (!targets || targets.length === 0) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -12,7 +12,8 @@ module.exports = {
   validateResponse: validateResponse,
   length: length,
   pathify: pathify,
-  printJSON: printJSON
+  printJSON: printJSON,
+  len: len
 }
 
 // http://goo.gl/LFoiYG
@@ -130,6 +131,11 @@ function length(description) {
     throw new TypeError('Handlebars Helper \'length\'' +
       'requires path to be a string');
   }
+
+  if (len === -1) { // toggle off truncation, this is a noop
+    return description;
+  }
+
   return strObj(description).truncate(len - 50).s;
 }
 

--- a/test/length/compare/request/base-path-test.js
+++ b/test/length/compare/request/base-path-test.js
@@ -1,0 +1,29 @@
+'use strict';
+var chai = require('chai');
+var request = require('request');
+
+chai.should();
+
+describe('/', function() {
+  describe('get', function() {
+    it('should respond with 200 OK, and this description is extra long for a simple length toggle test!', function(done) {
+      request({
+        url: 'http://basic.herokuapp.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) return done(error);
+
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/length/swagger.json
+++ b/test/length/swagger.json
@@ -1,0 +1,20 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "0.0.0",
+        "title": "Simple API"
+    },
+  "host": "basic.herokuapp.com",
+    "paths": {
+        "/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "OK, and this description is extra long for a simple length toggle test!"
+                    }
+                }
+            }
+
+        }
+    }
+}

--- a/test/length/test.js
+++ b/test/length/test.js
@@ -1,0 +1,76 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Apigee Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+/**
+ * This files tests is the user can set the template location
+ */
+'use strict';
+
+var assert = require('chai').assert;
+var testGen = require('../../index.js').testGen;
+var swagger = require('./swagger.json');
+var yaml = require('js-yaml');
+var join = require('path').join;
+var rules;
+
+var fs = require('fs');
+
+rules = yaml.safeLoad(fs.readFileSync(join(__dirname,
+  '/../../.eslintrc'), 'utf8'));
+rules.env = {mocha: true};
+
+describe('Toggle description truncation', function() {
+  var output = testGen(swagger, {
+    assertionFormat: 'should',
+    pathNames: [],
+    testModule: 'request',
+    maxLen: -1
+
+  });
+
+  it('should not truncate the description', function() {
+
+    var paths1 = [];
+    var ndx;
+
+    for (ndx in output) {
+      if (output) {
+        paths1.push(join(__dirname, '/compare/request/' + output[ndx].name));
+      }
+    }
+
+    assert.isArray(output);
+    assert.lengthOf(output, 1);
+
+    var generatedCode;
+
+    for (ndx in paths1) {
+      if (paths1 !== undefined) {
+        generatedCode = fs.readFileSync(paths1[ndx], 'utf8');
+        assert.equal(output[ndx].test, generatedCode);
+      }
+    }
+  });
+});


### PR DESCRIPTION
- adds functionality to toggle off description `maxLen` by passing `-1`
- updates `README`
- adds test file for description `maxLen` toggle 
- updates `.eslintrc` to allow for longer lines in this repo's source files (the test file has a long line)

Addesses `length` handlebars helper discussion from [#107](https://github.com/apigee-127/swagger-test-templates/pull/107)
